### PR TITLE
Updating readme to display hidden text

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Nuget dependencies:
 ## Setup
 In order to use the SDK the steps described below must be performed.
 1. Install TAP Driver as Administrator via command line: ./tapinstall.exe install "AFTap.inf" "aftap0901"
-2. Install VPN Windows Service as Administrator via command line: ./VpnService.exe -install <ServiceName>
-3. To uninstall service later: ./VpnService.exe -uninstall <ServiceName>
+2. Install VPN Windows Service as Administrator via command line: ./VpnService.exe -install \<ServiceName>
+3. To uninstall service later: ./VpnService.exe -uninstall \<ServiceName>
 
 ## Initialize
 ### CakeTube Class


### PR DESCRIPTION
It seems that when the readme renders the text that is "\<ServiceName>" is hidden because markdown see it as inline HTML, I've added a back slash to escape this functionality and display it in the doc